### PR TITLE
Bento pan zoom draft

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -807,6 +807,14 @@
     }
   },
   {
+    "name": "amp-pan-zoom",
+    "version": "1.0",
+    "options": {
+      "hasCss": true,
+      "bento": true
+    }
+  },
+  {
     "name": "amp-pinterest",
     "version": "0.1",
     "latestVersion": "0.1",

--- a/build-system/tasks/storybook/env/preact/package.json
+++ b/build-system/tasks/storybook/env/preact/package.json
@@ -4,7 +4,7 @@
   "description": "packages specific to the preact storybook env",
   "devDependencies": {
     "@storybook/preact": "6.3.12",
-    "preact-render-to-string": "5.1.19",
-    "preact": "10.5.15"
+    "preact": "10.5.15",
+    "preact-render-to-string": "5.1.19"
   }
 }

--- a/extensions/amp-pan-zoom/1.0/actions.ts
+++ b/extensions/amp-pan-zoom/1.0/actions.ts
@@ -1,0 +1,103 @@
+export const ACTION_TYPES = {
+  INITIALIZE_BOUNDS: 'INITIALIZE_BOUNDS',
+  SET_DIMENSIONS: 'SET_DIMENSIONS',
+  SET_CONTENT_BOX_OFFSETS: 'SET_CONTENT_BOX_OFFSETS',
+  CLEAR_DIMENSIONS: 'CLEAR_DIMENSIONS',
+  UPDATE_PAN_ZOOM: 'UPDATE_PAN_ZOOM',
+  UPDATE_PAN_ZOOM_BOUNDS: 'UPDATE_PAN_ZOOM_BOUNDS',
+  SET_ZOOM_BOUNDS: 'SET_ZOOM_BOUNDS',
+  UPDATE_CONTENT_DIMENSIONS: 'UPDATE_CONTENT_DIMENSIONS',
+  RESET_CONTENT_DIMENSIONS: 'RESET_CONTENT_DIMENSIONS',
+  TRANSFORM: 'TRANSFORM',
+  SET_IS_PANNING: 'SET_IS_PANNING',
+  MOVE: 'MOVE',
+  MOVE_RELEASE: 'MOVE_RELEASE',
+  ZOOM: 'ZOOM',
+} as const;
+
+const initializeBoundaries = ({
+  containerBox,
+  contentBox,
+}: {
+  contentBox: DOMRect;
+  containerBox: DOMRect;
+}) => ({
+  type: ACTION_TYPES.INITIALIZE_BOUNDS,
+  payload: {
+    contentBox,
+    containerBox,
+  },
+});
+
+type PositioningValues = {
+  x: number;
+  y: number;
+  scale: number;
+};
+
+const createZoomAction =
+  (isZoomed: boolean) =>
+  ({scale, x, y}: PositioningValues) => {
+    return {
+      type: ACTION_TYPES.ZOOM,
+      payload: {
+        isZoomed,
+        x,
+        y,
+        scale,
+      },
+    };
+  };
+
+const zoomIn = createZoomAction(true);
+const zoomOut = createZoomAction(false);
+
+const transformContent = ({scale, x, y}: PositioningValues) => {
+  return {
+    type: ACTION_TYPES.TRANSFORM,
+    payload: {x, y, scale},
+  };
+};
+
+const panContent = ({deltaX, deltaY}: {deltaX: number; deltaY: number}) => {
+  return {
+    type: ACTION_TYPES.MOVE,
+    payload: {
+      deltaX,
+      deltaY,
+    },
+  };
+};
+
+const startPanning = ({
+  mousePosX,
+  mousePosY,
+}: {
+  mousePosX: number;
+  mousePosY: number;
+}) => {
+  return {
+    type: ACTION_TYPES.SET_IS_PANNING,
+    payload: {isPannable: true, mousePosX, mousePosY},
+  };
+};
+
+const stopPanning = () => ({
+  type: ACTION_TYPES.SET_IS_PANNING,
+  payload: {isPannable: false},
+});
+
+export const actions = {
+  initializeBoundaries,
+  zoomIn,
+  zoomOut,
+  transformContent,
+  panContent,
+  startPanning,
+  stopPanning,
+};
+
+type ActionCreatorTypes = typeof actions;
+export type ActionTypes = ReturnType<
+  ActionCreatorTypes[keyof ActionCreatorTypes]
+>;

--- a/extensions/amp-pan-zoom/1.0/amp-pan-zoom.css
+++ b/extensions/amp-pan-zoom/1.0/amp-pan-zoom.css
@@ -1,0 +1,34 @@
+.amp-pan-zoom {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.amp-pan-zoom-child {
+ position: absolute;
+}
+
+.amp-pan-zoom-scrollable {
+ cursor: all-scroll;
+}
+
+.amp-pan-zoom-button {
+ position: absolute;
+ right: 12px;
+ width: 36px;
+ height: 36px;
+ bottom: 12px;
+ background-repeat: no-repeat;
+ background-position: center center;
+ box-shadow: 1px 1px 2px;
+ background-color: white;
+ border-radius: 3px;
+}
+
+.amp-pan-zoom-in-icon {
+ background-image: url('data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+}
+
+.amp-pan-zoom-out-icon {
+ background-image: url('data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13H5v-2h14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+}

--- a/extensions/amp-pan-zoom/1.0/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/1.0/amp-pan-zoom.js
@@ -1,0 +1,40 @@
+import {isExperimentOn} from '#experiments';
+
+import {AmpPreactBaseElement, setSuperClass} from '#preact/amp-base-element';
+
+import {userAssert} from '#utils/log';
+
+import {BaseElement} from './base-element';
+
+import {CSS} from '../../../build/amp-pan-zoom-1.0.css';
+
+/** @const {string} */
+const TAG = 'amp-pan-zoom';
+
+class AmpPanZoom extends setSuperClass(BaseElement, AmpPreactBaseElement) {
+  /** @override */
+  init() {
+    this.registerApiAction('exampleToggle', (api) =>
+      api./*OK*/ exampleToggle()
+    );
+
+    return {
+      // Extra props passed by wrapper AMP component
+      exampleTagNameProp: this.element.tagName,
+    };
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    userAssert(
+      isExperimentOn(this.win, 'bento') ||
+        isExperimentOn(this.win, 'bento-pan-zoom'),
+      'expected global "bento" or specific "bento-pan-zoom" experiment to be enabled'
+    );
+    return super.isLayoutSupported(layout);
+  }
+}
+
+AMP.extension(TAG, '1.0', (AMP) => {
+  AMP.registerElement(TAG, AmpPanZoom, CSS);
+});

--- a/extensions/amp-pan-zoom/1.0/base-element.js
+++ b/extensions/amp-pan-zoom/1.0/base-element.js
@@ -1,0 +1,25 @@
+import {PreactBaseElement} from '#preact/base-element';
+
+import {BentoPanZoom} from './component';
+import {CSS as COMPONENT_CSS} from './component.jss';
+
+export class BaseElement extends PreactBaseElement {}
+
+/** @override */
+BaseElement['Component'] = BentoPanZoom;
+
+/** @override */
+BaseElement['props'] = {
+  'children': {passthrough: true},
+  // 'children': {passthroughNonEmpty: true},
+  // 'children': {selector: '...'},
+};
+
+/** @override */
+BaseElement['layoutSizeDefined'] = true;
+
+/** @override */
+BaseElement['usesShadowDom'] = true;
+
+/** @override */
+BaseElement['shadowCss'] = COMPONENT_CSS;

--- a/extensions/amp-pan-zoom/1.0/component.js
+++ b/extensions/amp-pan-zoom/1.0/component.js
@@ -1,0 +1,238 @@
+import {bezierCurve} from '#core/data-structures/curve';
+import {
+  scale as cssScale,
+  getStyle,
+  setStyles,
+  translate,
+} from '#core/dom/style';
+
+import * as Preact from '#preact';
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from '#preact';
+import {Children, forwardRef} from '#preact/compat';
+import {ContainWrapper} from '#preact/component';
+import {logger} from '#preact/logger';
+
+import {useStyles} from './component.jss';
+import {ACTIONS, initReducer, panZoomReducer} from './reducer';
+const PAN_ZOOM_CURVE_ = bezierCurve(0.4, 0, 0.2, 1.4);
+const TAG = 'amp-pan-zoom';
+const DEFAULT_MAX_SCALE = 3;
+const DEFAULT_MIN_SCALE = 1;
+const DEFAULT_INITIAL_SCALE = 1;
+const MAX_ANIMATION_DURATION = 250;
+const DEFAULT_ORIGIN = 0;
+
+const ELIGIBLE_TAGS = new Set([
+  'svg',
+  'div',
+  'img',
+  // 'AMP-IMG',
+  // 'AMP-LAYOUT',
+  // 'AMP-SELECTOR',
+]);
+
+const useZoomAnimation = () => {};
+
+/**
+ * @param {!BentoPanZoom.Props} props
+ * @param {{current: ?BentoPanZoom.PanZoomApi}} ref
+ * @return {PreactDef.Renderable}
+ */
+export function BentoPanZoomWithRef(props, ref) {
+  const {
+    children,
+    controls,
+    initialScale = DEFAULT_INITIAL_SCALE,
+    initialX = DEFAULT_ORIGIN,
+    initialY = DEFAULT_ORIGIN,
+    maxScale = DEFAULT_MAX_SCALE,
+    onTransformEnd,
+    resetOnResize,
+    ...rest
+  } = props;
+  const styles = useStyles();
+  const childrenArray = useMemo(() => Children.toArray(children), [children]);
+
+  const contentRef = useRef(null);
+  const containerRef = useRef(null);
+
+  const [state, dispatch] = useReducer(panZoomReducer, props, initReducer);
+  const [mousePos, setMousePos] = useState({mousePosX: 0, mousePosY: 0});
+
+  useEffect(() => {
+    if (childrenArray.length !== 1) {
+      // this should also potentially check child types?
+      logger.error('BENTO-PAN-ZOOM', 'Component should only have one child');
+    }
+  }, [childrenArray]);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current && !contentRef.current) {
+      return;
+    }
+
+    dispatch({
+      type: ACTIONS.INITIALIZE_BOUNDS,
+      payload: {
+        contentBox: containerRef.current./*REVIEW*/ getBoundingClientRect(),
+        containerBox: contentRef.current./*REVIEW*/ getBoundingClientRect(),
+      },
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current && !contentRef.current) {
+      return;
+    }
+
+    const element = contentRef.current;
+    setStyles(element, {
+      transform: translate(state.posX, state.posY) + cssScale(state.scale),
+    });
+  }, [state.posX, state.posY, state.scale]);
+
+  const handleZoomButtonClick = (e) => {
+    if (!state.isZoomed) {
+      dispatch({type: ACTIONS.SET_IS_ZOOMED, payload: {isZoomed: true}});
+      dispatch({
+        type: ACTIONS.TRANSFORM,
+        payload: {x: 0, y: 0, scale: maxScale},
+      });
+    } else {
+      dispatch({type: ACTIONS.SET_IS_ZOOMED, payload: {isZoomed: false}});
+      dispatch({
+        type: ACTIONS.TRANSFORM,
+        payload: {x: 0, y: 0, scale: DEFAULT_MIN_SCALE},
+      });
+    }
+  };
+
+  // const resetContentDimensions = () => {
+  //   dispatch({type: ACTIONS.CLEAR_DIMENSIONS});
+  // };
+
+  // const setContentBoxOffsets = () => {
+  //   dispatch({
+  //     type: ACTIONS.SET_CONTENT_BOX_OFFSETS,
+  //     payload: {
+  //       contentBox: containerRef.current./*REVIEW*/ getBoundingClientRect(),
+  //     },
+  //   });
+  // };
+
+  const onMouseMove = useCallback(
+    (e) => {
+      // Prevent swiping by accident
+      e.preventDefault();
+
+      if (!state.isPannable) {
+        return;
+      }
+
+      const {clientX, clientY} = e;
+      const deltaX = clientX - mousePos.mousePosX;
+      const deltaY = clientY - mousePos.mousePosY;
+
+      dispatch({
+        type: ACTIONS.MOVE,
+        payload: {
+          posX: deltaX,
+          posY: deltaY,
+          element: contentRef.current,
+        },
+      });
+    },
+    [mousePos.mousePosX, mousePos.mousePosY, state.isPannable]
+  );
+
+  const onMouseDown = useCallback((e) => {
+    // Return early for right click
+    if (e.button == 2) {
+      return;
+    }
+
+    e.preventDefault();
+
+    const {clientX, clientY} = e;
+
+    dispatch({type: ACTIONS.SET_IS_PANNABLE, payload: {isPannable: true}});
+    setMousePos({
+      mousePosX: clientX,
+      mousePosY: clientY,
+    });
+  }, []);
+
+  const onMouseUp = useCallback((e) => {
+    e.preventDefault();
+
+    const {clientX, clientY} = e;
+
+    dispatch({
+      type: ACTIONS.MOVE_RELEASE,
+      payload: {
+        posX: clientX,
+        posY: clientY,
+      },
+    });
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () =>
+      /** @type {!BentoPanZoom.PanZoomApi} */ ({
+        transform: (scale, x, y) => {
+          dispatch({
+            type: ACTIONS.TRANSFORM,
+            payload: {
+              scale,
+              posX: x,
+              posY: y,
+            },
+          });
+        },
+      }),
+    []
+  );
+
+  const showPanCursor = state.isZoomed ? styles.ampPanZoomPannable : '';
+  const buttonClass = state.isZoomed
+    ? styles.ampPanZoomOutIcon
+    : styles.ampPanZoomInIcon;
+  return (
+    <ContainWrapper
+      {...rest}
+      ref={containerRef}
+      onMouseMove={onMouseMove}
+      class={styles.ampPanZoom}
+      contentClassName={styles.ampPanZoomContent}
+      layout
+    >
+      <div
+        ref={contentRef}
+        onMouseDown={onMouseDown}
+        onMouseUp={onMouseUp}
+        class={`${styles.ampPanZoomChild} ${showPanCursor}`}
+      >
+        {children}
+      </div>
+
+      <div
+        class={`${styles.ampPanZoomButton} ${buttonClass}`}
+        onClick={handleZoomButtonClick}
+      />
+    </ContainWrapper>
+  );
+}
+
+const BentoPanZoom = forwardRef(BentoPanZoomWithRef);
+BentoPanZoom.displayName = 'BentoPanZoom'; // Make findable for tests.
+export {BentoPanZoom};

--- a/extensions/amp-pan-zoom/1.0/component.jss.js
+++ b/extensions/amp-pan-zoom/1.0/component.jss.js
@@ -1,0 +1,64 @@
+import {createUseStyles} from 'react-jss';
+const ampPanZoom = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  overflow: 'hidden',
+};
+
+const ampPanZoomContent = {
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  overflow: 'hidden',
+};
+
+const ampPanZoomChild = {
+  position: 'absolute',
+  willChange: 'transform',
+};
+
+const ampPanZoomPannable = {
+  cursor: 'move',
+};
+
+const ampPanZoomButton = {
+  position: 'absolute',
+  right: '12px',
+  width: '36px',
+  height: '36px',
+  bottom: '12px',
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'center center',
+  boxShadow: '1px 1px 2px',
+  backgroundColor: 'white',
+  borderRadius: '3px',
+};
+
+const ampPanZoomInIcon = {
+  backgroundImage: `url(
+    'data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>'
+  )`,
+};
+
+const ampPanZoomOutIcon = {
+  backgroundImage: `url(
+    'data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13H5v-2h14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>'
+  )`,
+};
+
+const JSS = {
+  ampPanZoom,
+  ampPanZoomChild,
+  ampPanZoomContent,
+  ampPanZoomPannable,
+  ampPanZoomButton,
+  ampPanZoomInIcon,
+  ampPanZoomOutIcon,
+};
+
+// useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.
+// eslint-disable-next-line local/no-export-side-effect
+export const useStyles = createUseStyles(JSS);

--- a/extensions/amp-pan-zoom/1.0/component.type.js
+++ b/extensions/amp-pan-zoom/1.0/component.type.js
@@ -1,0 +1,28 @@
+/** @externs */
+
+/** @const */
+var BentoPanZoomDef = {};
+
+/**
+ * @typedef {{
+ *   children: (?PreactDef.Renderable|undefined),
+ *   controls: (boolean|undefined),
+ *   initialScale: (number|undefined),
+ *   initialX: (number|undefined),
+ *   initialY: (number|undefined),
+ *   maxScale: (number|undefined),
+ *   onTransformEnd: (function(number, number, number):undefined),
+ *   resetOnResize: (boolean|undefined),
+ * }}
+ */
+BentoPanZoomDef.Props;
+
+/** @interface */
+BentoPanZoomDef.PanZoomApi = class {
+  /**
+   * @param {number} scale
+   * @param {number} x
+   * @param {number} y
+   */
+  transform(scale, x, y) {}
+};

--- a/extensions/amp-pan-zoom/1.0/not_yet_used.ts
+++ b/extensions/amp-pan-zoom/1.0/not_yet_used.ts
@@ -1,0 +1,83 @@
+import {bezierCurve} from '#core/data-structures/curve';
+import {layoutRectLtwh} from '#core/dom/layout/rect';
+
+// This file is simply almost verbatim ported work from the 0.1 version, but I either hadn't needed them yet, or won't need them, but in case they're useful to you
+
+// State stub that would otherwise rely on the value in ./reducers but I didn't want to export this type
+type State = {};
+const PAN_ZOOM_CURVE = bezierCurve(0.4, 0, 0.2, 1.4);
+const ANIMATION_EASE_IN = 'cubic-bezier(0,0,.21,1)';
+const updateContentDimensions = (
+  sourceHeight: number,
+  sourceWidth: number,
+  aspectRatio: number,
+  containerBox: DOMRect
+) => {
+  // Calculate content height if we set width to amp-pan-zoom's width
+  const heightToFit = containerBox.width / aspectRatio;
+  // Calculate content width if we set height to be amp-pan-zoom's height
+  const widthToFit = containerBox.height * aspectRatio;
+  // The content should fit within amp-pan-zoom, so take the smaller value
+  let height = Math.min(heightToFit, containerBox.height);
+  let width = Math.min(widthToFit, containerBox.width);
+  if (
+    Math.abs(width - sourceWidth) <= 16 &&
+    Math.abs(height - sourceHeight) <= 16
+  ) {
+    width = sourceWidth;
+    height = sourceHeight;
+  }
+  return layoutRectLtwh(0, 0, Math.round(width), Math.round(height));
+};
+
+const resetContentDimensions = () => {};
+
+const updateMaxScale = (
+  maxScale: number,
+  aspectRatio: number,
+  containerBox: DOMRect
+) => {
+  const {height, width} = containerBox;
+  const containerBoxRatio = width / height;
+  const newMaxScale = Math.max(
+    containerBoxRatio / aspectRatio,
+    aspectRatio / containerBoxRatio
+  );
+  if (!isNaN(newMaxScale)) {
+    return Math.max(maxScale, newMaxScale);
+  }
+  return maxScale;
+};
+
+const measure = (
+  state: State,
+  contentWidth: number,
+  contentHeight: number,
+  containerBoxRect: DOMRect
+) => {
+  const sourceAspectRatio = contentWidth / contentHeight;
+  return {
+    sourceWidth: contentWidth,
+    sourceHeight: contentHeight,
+    maxScale: updateMaxScale(
+      state.maxScale,
+      sourceAspectRatio,
+      containerBoxRect
+    ),
+    containerBox: containerBoxRect,
+    contentBox: updateContentDimensions(
+      contentWidth,
+      contentHeight,
+      sourceAspectRatio,
+      containerBoxRect
+    ),
+  };
+};
+
+const setContentBox = (contentBox: DOMRect, containerBox: DOMRect) => {
+  return {
+    ...contentBox,
+    top: contentBox.top - containerBox.top,
+    left: contentBox.left - containerBox.left,
+  };
+};

--- a/extensions/amp-pan-zoom/1.0/reducer.ts
+++ b/extensions/amp-pan-zoom/1.0/reducer.ts
@@ -1,0 +1,393 @@
+import {bezierCurve} from '#core/data-structures/curve';
+import {layoutRectLtwh} from '#core/dom/layout/rect';
+import {scale as cssScale, px, translate} from '#core/dom/style';
+import {numeric} from '#core/dom/transition';
+import {boundValue, distance} from '#core/math';
+
+const PAN_ZOOM_CURVE = bezierCurve(0.4, 0, 0.2, 1.4);
+const ANIMATION_EASE_IN = 'cubic-bezier(0,0,.21,1)';
+const DEFAULT_MAX_SCALE = 3;
+const DEFAULT_INITIAL_SCALE = 1;
+const MAX_ANIMATION_DURATION = 250;
+const DEFAULT_ORIGIN = 0;
+
+export const ACTIONS = {
+  INITIALIZE_BOUNDS: 'INITIALIZE_BOUNDS',
+  SET_DIMENSIONS: 'SET_DIMENSIONS',
+  SET_CONTENT_BOX_OFFSETS: 'SET_CONTENT_BOX_OFFSETS',
+  CLEAR_DIMENSIONS: 'CLEAR_DIMENSIONS',
+  UPDATE_PAN_ZOOM: 'UPDATE_PAN_ZOOM',
+  UPDATE_PAN_ZOOM_BOUNDS: 'UPDATE_PAN_ZOOM_BOUNDS',
+  SET_ZOOM_BOUNDS: 'SET_ZOOM_BOUNDS',
+  UPDATE_CONTENT_DIMENSIONS: 'UPDATE_CONTENT_DIMENSIONS',
+  RESET_CONTENT_DIMENSIONS: 'RESET_CONTENT_DIMENSIONS',
+  TRANSFORM: 'TRANSFORM',
+  SET_IS_ZOOMED: 'SET_IS_ZOOMED',
+  SET_IS_PANNABLE: 'SET_IS_PANNABLE',
+  MOVE: 'MOVE',
+  MOVE_RELEASE: 'MOVE_RELEASE',
+};
+
+const initialRect = new DOMRect(0, 0, 0, 0);
+
+type InitialState = {
+  maxX: number;
+  minX: number;
+  startX: number;
+  posX: number;
+
+  maxY: number;
+  minY: number;
+  startY: number;
+  posY: number;
+
+  minScale: number;
+  maxScale: number;
+  scale: number;
+
+  width: number;
+  sourceWidth: number;
+  height: number;
+  sourceHeight: number;
+  transform: string;
+
+  contentBox: DOMRect;
+  containerBox: DOMRect;
+
+  isPannable: boolean;
+  isZoomed: boolean;
+};
+
+type State = InitialState;
+
+const initialState: InitialState = {
+  maxX: 0,
+  minX: 0,
+  startX: 0,
+  posX: 0,
+
+  maxY: 0,
+  minY: 0,
+  startY: 0,
+  posY: 0,
+
+  minScale: 1,
+  maxScale: DEFAULT_MAX_SCALE,
+  scale: 1,
+
+  width: 0,
+  sourceWidth: 0,
+  height: 0,
+  sourceHeight: 0,
+  transform: '',
+
+  contentBox: initialRect,
+  containerBox: initialRect,
+
+  isPannable: false,
+  isZoomed: false,
+};
+
+const updatePanZoomBoundaries = (state: State, newScale: number) => {
+  const {containerBox, contentBox} = state;
+  const {
+    height: contentHeight,
+    left: contentXOffset,
+    top: contentYOffset,
+    width: contentWidth,
+  } = contentBox;
+  const {height: elementHeight, width: elementWidth} = containerBox;
+  const minX = Math.min(
+    0,
+    elementWidth - (contentXOffset + (contentWidth * (newScale + 1)) / 2)
+  );
+  const maxX = Math.max(
+    0,
+    (contentWidth * newScale - contentWidth) / 2 - contentXOffset
+  );
+  const minY = Math.min(
+    0,
+    elementHeight - (contentYOffset + (contentHeight * (newScale + 1)) / 2)
+  );
+  const maxY = Math.max(
+    0,
+    (contentHeight * newScale - contentHeight) / 2 - contentYOffset
+  );
+  return {
+    maxX,
+    minX,
+    maxY,
+    minY,
+  };
+};
+
+const updateContentDimensions = (
+  sourceHeight: number,
+  sourceWidth: number,
+  aspectRatio: number,
+  containerBox: DOMRect
+) => {
+  // Calculate content height if we set width to amp-pan-zoom's width
+  const heightToFit = containerBox.width / aspectRatio;
+  // Calculate content width if we set height to be amp-pan-zoom's height
+  const widthToFit = containerBox.height * aspectRatio;
+  // The content should fit within amp-pan-zoom, so take the smaller value
+  let height = Math.min(heightToFit, containerBox.height);
+  let width = Math.min(widthToFit, containerBox.width);
+  if (
+    Math.abs(width - sourceWidth) <= 16 &&
+    Math.abs(height - sourceHeight) <= 16
+  ) {
+    width = sourceWidth;
+    height = sourceHeight;
+  }
+  return layoutRectLtwh(0, 0, Math.round(width), Math.round(height));
+};
+
+const resetContentDimensions = () => {};
+
+const updateMaxScale = (
+  maxScale: number,
+  aspectRatio: number,
+  containerBox: DOMRect
+) => {
+  const {height, width} = containerBox;
+  const containerBoxRatio = width / height;
+  const newMaxScale = Math.max(
+    containerBoxRatio / aspectRatio,
+    aspectRatio / containerBoxRatio
+  );
+  if (!isNaN(newMaxScale)) {
+    return Math.max(maxScale, newMaxScale);
+  }
+  return maxScale;
+};
+
+const measure = (
+  state: State,
+  contentWidth: number,
+  contentHeight: number,
+  containerBoxRect: DOMRect
+) => {
+  const sourceAspectRatio = contentWidth / contentHeight;
+  return {
+    sourceWidth: contentWidth,
+    sourceHeight: contentHeight,
+    maxScale: updateMaxScale(
+      state.maxScale,
+      sourceAspectRatio,
+      containerBoxRect
+    ),
+    containerBox: containerBoxRect,
+    contentBox: updateContentDimensions(
+      contentWidth,
+      contentHeight,
+      sourceAspectRatio,
+      containerBoxRect
+    ),
+  };
+};
+
+const setContentBox = (contentBox: DOMRect, containerBox: DOMRect) => {
+  return {
+    ...contentBox,
+    top: contentBox.top - containerBox.top,
+    left: contentBox.left - containerBox.left,
+  };
+};
+
+const boundScale = (state: State, newScale: number, allowExtent: boolean) => {
+  const {maxScale, minScale} = state;
+  const extent = allowExtent ? 0.25 : 0;
+  return boundValue(newScale, minScale, maxScale, extent);
+};
+
+const boundX = (state: State, newPosX: number, allowExtent: boolean) => {
+  const {containerBox, maxX, minX, scale} = state;
+  const maxExtent = containerBox.width * 0.25;
+  const extent = allowExtent && scale > 1 ? maxExtent : 0;
+  return boundValue(newPosX, minX, maxX, extent);
+};
+
+const boundY = (state: State, newPosY: number, allowExtent: boolean) => {
+  const {containerBox, maxY, minY, scale} = state;
+  const maxExtent = containerBox.height * 0.25;
+  const extent = allowExtent && scale > 1 ? maxExtent : 0;
+  return boundValue(newPosY, minY, maxY, extent);
+};
+
+const transform = (state: State, x: number, y: number, scale: number) => {
+  const newX = boundX(state, x, false);
+  const newY = boundY(state, y, false);
+
+  return setZoomParams(state, scale, newX, newY, true);
+};
+
+const move = (state: State, x: number, y: number, element: any) => {
+  const newX = boundX(state, x, false);
+  const newY = boundY(state, y, false);
+  return setZoomParams(state, state.scale, newX, newY, false, element);
+};
+
+const moveRelease = (state: State, x: number, y: number, animate: boolean) => {
+  const newX = boundX(state, x, false);
+  const newY = boundY(state, y, false);
+  return setZoomParams(state, state.scale, newX, newY, animate);
+};
+
+// this needs to return a promise or at least a thenable
+const setZoomParams = (
+  state: State,
+  newScale: number,
+  newPosX: number,
+  newPosY: number,
+  animate: boolean,
+  elementRef?: any
+) => {
+  const {posX, posY, scale} = state;
+  const ds = newScale - scale;
+  const dist = distance(posX, posY, newPosX, newPosY);
+  const dur = animate
+    ? Math.min(
+        1,
+        Math.max(
+          dist * 0.01, // Distance
+          Math.abs(ds) // Change in scale
+        )
+      ) * MAX_ANIMATION_DURATION
+    : 0;
+
+  if (dur > 16 && animate && elementRef) {
+    // should be Animation
+    const scaleFunc = numeric(scale, newScale);
+    const xFunc = numeric(posX, newPosX);
+    const yFunc = numeric(posY, newPosY);
+    const time = dur;
+
+    return {
+      scale: scaleFunc(time),
+      posX: xFunc(time),
+      posY: yFunc(time),
+    };
+    // const keys = getKeyframes(xFunc(time), yFunc(time), scaleFunc(time));
+    // elementRef.animate(keys, {
+    //   easing: PAN_ZOOM_CURVE,
+    //   duration: 10000,
+    //   fill: 'both',
+    // });
+  } else {
+    return {
+      scale: newScale,
+      posX: newPosX,
+      posY: newPosY,
+    };
+  }
+};
+// keyframes
+// {
+//   duration: ANIMATION_DURATION,
+//   fill: 'both',
+//   easing: ANIMATION_EASE_IN,
+// }
+
+const getKeyframes = (posX, posY, scale) => {
+  return [{transform: translate(posX, posY) + cssScale(scale)}];
+};
+
+export function initReducer(config) {
+  const {initialScale, initialX, initialY, maxScale} = config;
+  return {
+    ...initialState,
+    initialScale: initialScale || DEFAULT_INITIAL_SCALE,
+    initialX: initialX || DEFAULT_ORIGIN,
+    initialY: initialY || DEFAULT_ORIGIN,
+    maxScale: maxScale || DEFAULT_MAX_SCALE,
+  };
+}
+
+export function panZoomReducer(state: InitialState, action) {
+  switch (action.type) {
+    case ACTIONS.INITIALIZE_BOUNDS:
+      return {
+        ...state,
+        contentBox: action.payload.contentBox,
+        containerBox: action.payload.containerBox,
+      };
+    case ACTIONS.SET_DIMENSIONS:
+      return {
+        ...state,
+        height: px(state.contentBox?.height),
+        width: px(state.contentBox?.width),
+      };
+    case ACTIONS.CLEAR_DIMENSIONS:
+      return {
+        ...state,
+        height: '',
+        width: '',
+      };
+    case ACTIONS.UPDATE_PAN_ZOOM:
+      const transformString = `translate(${state.posX}px ${state.posY}px) scale(${state.scale})`;
+      return {
+        ...state,
+        transform: transformString,
+      };
+    case ACTIONS.UPDATE_PAN_ZOOM_BOUNDS:
+      return {
+        ...state,
+        ...updatePanZoomBoundaries(state, action.payload.scale),
+      };
+    case ACTIONS.SET_CONTENT_BOX_OFFSETS:
+      return {
+        ...state,
+        ...setContentBox(action.payload.contentBox, state.containerBox),
+      };
+    case ACTIONS.SET_IS_PANNABLE:
+      // temp work around for clicking on zoom button
+      if (!state.isZoomed) {
+        return state;
+      } else {
+        return {
+          ...state,
+          isPannable: action.payload.isPannable,
+        };
+      }
+    case ACTIONS.SET_IS_ZOOMED:
+      return {
+        ...state,
+        isZoomed: action.payload.isZoomed,
+      };
+    case ACTIONS.UPDATE_CONTENT_DIMENSIONS:
+      return {
+        ...state,
+        ...updatePanZoomBoundaries(state, action.payload.scale),
+      };
+    case ACTIONS.MOVE:
+      return {
+        ...state,
+        ...move(
+          state,
+          action.payload.posX,
+          action.payload.posY,
+          action.payload.element
+        ),
+      };
+    case ACTIONS.MOVE_RELEASE:
+      return {
+        ...state,
+        isPannable: false,
+      };
+    case ACTIONS.TRANSFORM:
+      return {
+        ...state,
+        ...updatePanZoomBoundaries(state, action.payload.scale),
+        ...transform(
+          state,
+          action.payload.x,
+          action.payload.y,
+          action.payload.scale
+        ),
+      };
+    default:
+      return state;
+  }
+}

--- a/extensions/amp-pan-zoom/1.0/reducer.ts
+++ b/extensions/amp-pan-zoom/1.0/reducer.ts
@@ -1,32 +1,10 @@
-import {bezierCurve} from '#core/data-structures/curve';
-import {layoutRectLtwh} from '#core/dom/layout/rect';
-import {scale as cssScale, px, translate} from '#core/dom/style';
-import {numeric} from '#core/dom/transition';
 import {boundValue, distance} from '#core/math';
 
-const PAN_ZOOM_CURVE = bezierCurve(0.4, 0, 0.2, 1.4);
-const ANIMATION_EASE_IN = 'cubic-bezier(0,0,.21,1)';
+import {ACTION_TYPES, ActionTypes} from './actions';
 const DEFAULT_MAX_SCALE = 3;
 const DEFAULT_INITIAL_SCALE = 1;
 const MAX_ANIMATION_DURATION = 250;
 const DEFAULT_ORIGIN = 0;
-
-export const ACTIONS = {
-  INITIALIZE_BOUNDS: 'INITIALIZE_BOUNDS',
-  SET_DIMENSIONS: 'SET_DIMENSIONS',
-  SET_CONTENT_BOX_OFFSETS: 'SET_CONTENT_BOX_OFFSETS',
-  CLEAR_DIMENSIONS: 'CLEAR_DIMENSIONS',
-  UPDATE_PAN_ZOOM: 'UPDATE_PAN_ZOOM',
-  UPDATE_PAN_ZOOM_BOUNDS: 'UPDATE_PAN_ZOOM_BOUNDS',
-  SET_ZOOM_BOUNDS: 'SET_ZOOM_BOUNDS',
-  UPDATE_CONTENT_DIMENSIONS: 'UPDATE_CONTENT_DIMENSIONS',
-  RESET_CONTENT_DIMENSIONS: 'RESET_CONTENT_DIMENSIONS',
-  TRANSFORM: 'TRANSFORM',
-  SET_IS_ZOOMED: 'SET_IS_ZOOMED',
-  SET_IS_PANNABLE: 'SET_IS_PANNABLE',
-  MOVE: 'MOVE',
-  MOVE_RELEASE: 'MOVE_RELEASE',
-};
 
 const initialRect = new DOMRect(0, 0, 0, 0);
 
@@ -45,6 +23,9 @@ type InitialState = {
   maxScale: number;
   scale: number;
 
+  mousePosX: number;
+  mousePosY: number;
+
   width: number;
   sourceWidth: number;
   height: number;
@@ -58,7 +39,7 @@ type InitialState = {
   isZoomed: boolean;
 };
 
-type State = InitialState;
+export type State = InitialState;
 
 const initialState: InitialState = {
   maxX: 0,
@@ -74,6 +55,9 @@ const initialState: InitialState = {
   minScale: 1,
   maxScale: DEFAULT_MAX_SCALE,
   scale: 1,
+
+  mousePosX: 0,
+  mousePosY: 0,
 
   width: 0,
   sourceWidth: 0,
@@ -121,81 +105,6 @@ const updatePanZoomBoundaries = (state: State, newScale: number) => {
   };
 };
 
-const updateContentDimensions = (
-  sourceHeight: number,
-  sourceWidth: number,
-  aspectRatio: number,
-  containerBox: DOMRect
-) => {
-  // Calculate content height if we set width to amp-pan-zoom's width
-  const heightToFit = containerBox.width / aspectRatio;
-  // Calculate content width if we set height to be amp-pan-zoom's height
-  const widthToFit = containerBox.height * aspectRatio;
-  // The content should fit within amp-pan-zoom, so take the smaller value
-  let height = Math.min(heightToFit, containerBox.height);
-  let width = Math.min(widthToFit, containerBox.width);
-  if (
-    Math.abs(width - sourceWidth) <= 16 &&
-    Math.abs(height - sourceHeight) <= 16
-  ) {
-    width = sourceWidth;
-    height = sourceHeight;
-  }
-  return layoutRectLtwh(0, 0, Math.round(width), Math.round(height));
-};
-
-const resetContentDimensions = () => {};
-
-const updateMaxScale = (
-  maxScale: number,
-  aspectRatio: number,
-  containerBox: DOMRect
-) => {
-  const {height, width} = containerBox;
-  const containerBoxRatio = width / height;
-  const newMaxScale = Math.max(
-    containerBoxRatio / aspectRatio,
-    aspectRatio / containerBoxRatio
-  );
-  if (!isNaN(newMaxScale)) {
-    return Math.max(maxScale, newMaxScale);
-  }
-  return maxScale;
-};
-
-const measure = (
-  state: State,
-  contentWidth: number,
-  contentHeight: number,
-  containerBoxRect: DOMRect
-) => {
-  const sourceAspectRatio = contentWidth / contentHeight;
-  return {
-    sourceWidth: contentWidth,
-    sourceHeight: contentHeight,
-    maxScale: updateMaxScale(
-      state.maxScale,
-      sourceAspectRatio,
-      containerBoxRect
-    ),
-    containerBox: containerBoxRect,
-    contentBox: updateContentDimensions(
-      contentWidth,
-      contentHeight,
-      sourceAspectRatio,
-      containerBoxRect
-    ),
-  };
-};
-
-const setContentBox = (contentBox: DOMRect, containerBox: DOMRect) => {
-  return {
-    ...contentBox,
-    top: contentBox.top - containerBox.top,
-    left: contentBox.left - containerBox.left,
-  };
-};
-
 const boundScale = (state: State, newScale: number, allowExtent: boolean) => {
   const {maxScale, minScale} = state;
   const extent = allowExtent ? 0.25 : 0;
@@ -220,29 +129,21 @@ const transform = (state: State, x: number, y: number, scale: number) => {
   const newX = boundX(state, x, false);
   const newY = boundY(state, y, false);
 
-  return setZoomParams(state, scale, newX, newY, true);
+  return setZoomCoordsAndScale(state, scale, newX, newY, true);
 };
 
-const move = (state: State, x: number, y: number, element: any) => {
-  const newX = boundX(state, x, false);
-  const newY = boundY(state, y, false);
-  return setZoomParams(state, state.scale, newX, newY, false, element);
+const move = (state: State, deltaX: number, deltaY: number) => {
+  const newX = boundX(state, deltaX + state.startX, false);
+  const newY = boundY(state, deltaY + state.startY, false);
+  return setZoomCoordsAndScale(state, state.scale, newX, newY, false);
 };
 
-const moveRelease = (state: State, x: number, y: number, animate: boolean) => {
-  const newX = boundX(state, x, false);
-  const newY = boundY(state, y, false);
-  return setZoomParams(state, state.scale, newX, newY, animate);
-};
-
-// this needs to return a promise or at least a thenable
-const setZoomParams = (
+const setZoomCoordsAndScale = (
   state: State,
   newScale: number,
   newPosX: number,
   newPosY: number,
-  animate: boolean,
-  elementRef?: any
+  animate: boolean
 ) => {
   const {posX, posY, scale} = state;
   const ds = newScale - scale;
@@ -257,41 +158,31 @@ const setZoomParams = (
       ) * MAX_ANIMATION_DURATION
     : 0;
 
-  if (dur > 16 && animate && elementRef) {
-    // should be Animation
-    const scaleFunc = numeric(scale, newScale);
-    const xFunc = numeric(posX, newPosX);
-    const yFunc = numeric(posY, newPosY);
-    const time = dur;
+  // initial porting of animation logic, but this is the wrong place to do it
+  // if (dur > 16 && animate && elementRef) {
+  //   // should be Animation
+  //   const scaleFunc = numeric(scale, newScale);
+  //   const xFunc = numeric(posX, newPosX);
+  //   const yFunc = numeric(posY, newPosY);
+  //   const time = dur;
 
-    return {
-      scale: scaleFunc(time),
-      posX: xFunc(time),
-      posY: yFunc(time),
-    };
-    // const keys = getKeyframes(xFunc(time), yFunc(time), scaleFunc(time));
-    // elementRef.animate(keys, {
-    //   easing: PAN_ZOOM_CURVE,
-    //   duration: 10000,
-    //   fill: 'both',
-    // });
-  } else {
-    return {
-      scale: newScale,
-      posX: newPosX,
-      posY: newPosY,
-    };
-  }
-};
-// keyframes
-// {
-//   duration: ANIMATION_DURATION,
-//   fill: 'both',
-//   easing: ANIMATION_EASE_IN,
-// }
-
-const getKeyframes = (posX, posY, scale) => {
-  return [{transform: translate(posX, posY) + cssScale(scale)}];
+  //   return {
+  //     scale: scaleFunc(time),
+  //     posX: xFunc(time),
+  //     posY: yFunc(time),
+  //   };
+  // } else {
+  //   return {
+  //     scale: newScale,
+  //     posX: newPosX,
+  //     posY: newPosY,
+  //   };
+  // }
+  return {
+    scale: newScale,
+    posX: newPosX,
+    posY: newPosY,
+  };
 };
 
 export function initReducer(config) {
@@ -305,78 +196,46 @@ export function initReducer(config) {
   };
 }
 
-export function panZoomReducer(state: InitialState, action) {
+export function panZoomReducer(state: InitialState, action: ActionTypes) {
   switch (action.type) {
-    case ACTIONS.INITIALIZE_BOUNDS:
+    case ACTION_TYPES.INITIALIZE_BOUNDS:
       return {
         ...state,
         contentBox: action.payload.contentBox,
         containerBox: action.payload.containerBox,
       };
-    case ACTIONS.SET_DIMENSIONS:
-      return {
-        ...state,
-        height: px(state.contentBox?.height),
-        width: px(state.contentBox?.width),
-      };
-    case ACTIONS.CLEAR_DIMENSIONS:
-      return {
-        ...state,
-        height: '',
-        width: '',
-      };
-    case ACTIONS.UPDATE_PAN_ZOOM:
-      const transformString = `translate(${state.posX}px ${state.posY}px) scale(${state.scale})`;
-      return {
-        ...state,
-        transform: transformString,
-      };
-    case ACTIONS.UPDATE_PAN_ZOOM_BOUNDS:
-      return {
-        ...state,
-        ...updatePanZoomBoundaries(state, action.payload.scale),
-      };
-    case ACTIONS.SET_CONTENT_BOX_OFFSETS:
-      return {
-        ...state,
-        ...setContentBox(action.payload.contentBox, state.containerBox),
-      };
-    case ACTIONS.SET_IS_PANNABLE:
-      // temp work around for clicking on zoom button
+    case ACTION_TYPES.SET_IS_PANNING:
+      // temp work around for clicking on zoom button triggering move
       if (!state.isZoomed) {
         return state;
       } else {
         return {
           ...state,
           isPannable: action.payload.isPannable,
+          startX: state.posX,
+          startY: state.posY,
+          mousePosX: action.payload?.mousePosX || 0,
+          mousePosY: action.payload?.mousePosY || 0,
         };
       }
-    case ACTIONS.SET_IS_ZOOMED:
+    case ACTION_TYPES.ZOOM:
       return {
         ...state,
         isZoomed: action.payload.isZoomed,
-      };
-    case ACTIONS.UPDATE_CONTENT_DIMENSIONS:
-      return {
-        ...state,
         ...updatePanZoomBoundaries(state, action.payload.scale),
-      };
-    case ACTIONS.MOVE:
-      return {
-        ...state,
-        ...move(
+        ...transform(
           state,
-          action.payload.posX,
-          action.payload.posY,
-          action.payload.element
+          action.payload.x,
+          action.payload.y,
+          action.payload.scale
         ),
       };
-    case ACTIONS.MOVE_RELEASE:
+    case ACTION_TYPES.MOVE:
       return {
         ...state,
-        isPannable: false,
+        ...move(state, action.payload.deltaX, action.payload.deltaY),
       };
-    case ACTIONS.TRANSFORM:
+    case ACTION_TYPES.TRANSFORM:
       return {
         ...state,
         ...updatePanZoomBoundaries(state, action.payload.scale),
@@ -387,6 +246,41 @@ export function panZoomReducer(state: InitialState, action) {
           action.payload.scale
         ),
       };
+
+    // not currently used, but functionality ported over form .1 version
+    // case ACTION_TYPES.SET_DIMENSIONS:
+    //   return {
+    //     ...state,
+    //     height: px(state.contentBox?.height),
+    //     width: px(state.contentBox?.width),
+    //   };
+    // case ACTION_TYPES.CLEAR_DIMENSIONS:
+    //   return {
+    //     ...state,
+    //     height: '',
+    //     width: '',
+    //   };
+    // case ACTION_TYPES.UPDATE_PAN_ZOOM:
+    //   const transformString = `translate(${state.posX}px ${state.posY}px) scale(${state.scale})`;
+    //   return {
+    //     ...state,
+    //     transform: transformString,
+    //   };
+    // case ACTION_TYPES.UPDATE_PAN_ZOOM_BOUNDS:
+    //   return {
+    //     ...state,
+    //     ...updatePanZoomBoundaries(state, action.payload.scale),
+    //   };
+    // case ACTION_TYPES.SET_CONTENT_BOX_OFFSETS:
+    //   return {
+    //     ...state,
+    //     ...setContentBox(action.payload.contentBox, state.containerBox),
+    //   };
+    // case ACTION_TYPES.UPDATE_CONTENT_DIMENSIONS:
+    //   return {
+    //     ...state,
+    //     ...updatePanZoomBoundaries(state, action.payload.scale),
+    //   };
     default:
       return state;
   }

--- a/extensions/amp-pan-zoom/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-pan-zoom/1.0/storybook/Basic.amp.js
@@ -1,0 +1,23 @@
+import {withAmp} from '@ampproject/storybook-addon';
+
+import * as Preact from '#preact';
+
+export default {
+  title: 'amp-pan-zoom-1_0',
+  decorators: [withAmp],
+  parameters: {
+    extensions: [{name: 'amp-pan-zoom', version: '1.0'}],
+    experiments: ['bento'],
+  },
+  args: {
+    'data-example-property': 'example string property argument',
+  },
+};
+
+export const _default = (args) => {
+  return (
+    <amp-pan-zoom width="300" height="200" {...args}>
+      This text is inside.
+    </amp-pan-zoom>
+  );
+};

--- a/extensions/amp-pan-zoom/1.0/storybook/Basic.js
+++ b/extensions/amp-pan-zoom/1.0/storybook/Basic.js
@@ -1,0 +1,30 @@
+import * as Preact from '#preact';
+
+import {BentoPanZoom} from '../component';
+
+export default {
+  title: 'PanZoom',
+  component: BentoPanZoom,
+  args: {},
+};
+
+const Foo = ({children}) => <div>Foo stuff{children}</div>;
+
+export const _default = () => {
+  return (
+    <BentoPanZoom style={{width: 300, height: 200}}>
+      <Foo>
+        <span>This text is inside.</span>
+        This text is inside.
+      </Foo>
+    </BentoPanZoom>
+  );
+};
+
+// export const _default = (args) => {
+//   return (
+//     <BentoPanZoom style={{width: 300, height: 200}} {...args}>
+//       This text is inside.
+//     </BentoPanZoom>
+//   );
+// };

--- a/extensions/amp-pan-zoom/1.0/test/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/1.0/test/test-amp-pan-zoom.js
@@ -1,0 +1,33 @@
+import '../amp-pan-zoom';
+import {htmlFor} from '#core/dom/static-template';
+import {toggleExperiment} from '#experiments';
+import {waitFor} from '#testing/helpers/service';
+
+describes.realWin(
+  'amp-pan-zoom-v1.0',
+  {
+    amp: {
+      extensions: ['amp-pan-zoom:1.0'],
+    },
+  },
+  (env) => {
+    let win;
+    let doc;
+    let html;
+
+    beforeEach(async () => {
+      win = env.win;
+      doc = win.document;
+      html = htmlFor(doc);
+      toggleExperiment(win, 'bento-pan-zoom', true, true);
+    });
+
+    // DO NOT SUBMIT: This is example code only.
+    it('example test renders', async () => {
+      const element = html` <amp-pan-zoom></amp-pan-zoom> `;
+      doc.body.appendChild(element);
+      await waitFor(() => element.isConnected, 'element connected');
+      expect(element.parentNode).to.equal(doc.body);
+    });
+  }
+);

--- a/extensions/amp-pan-zoom/1.0/test/test-component.js
+++ b/extensions/amp-pan-zoom/1.0/test/test-component.js
@@ -1,0 +1,14 @@
+import * as Preact from '#preact';
+import {BentoPanZoom} from '../component';
+import {mount} from 'enzyme';
+
+describes.sandboxed('BentoPanZoom preact component v1.0', {}, (env) => {
+  // DO NOT SUBMIT: This is example code only.
+  it('should render', () => {
+    const wrapper = mount(<BentoPanZoom testProp={true} />);
+
+    const component = wrapper.find(BentoPanZoom.name);
+    expect(component).to.have.lengthOf(1);
+    expect(component.prop('testProp')).to.be.true;
+  });
+});

--- a/extensions/amp-pan-zoom/1.0/test/validator-amp-pan-zoom.html
+++ b/extensions/amp-pan-zoom/1.0/test/validator-amp-pan-zoom.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html ⚡ lang="en">
+  <!-- prettier-ignore -->
+  <head>
+    <meta charset="utf-8">
+    <title>amp-pan-zoom example</title>
+    <link rel="canonical" href="/examples/amp-pan-zoom.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      amp-pan-zoom {
+        color: red;
+      }
+    </style>
+    <script async custom-element="amp-pan-zoom" src="https://cdn.ampproject.org/v0/amp-pan-zoom-1.0.js"></script>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+  </head>
+  <body>
+    <amp-pan-zoom layout="responsive" width="150" height="80"></amp-pan-zoom>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5808,7 +5808,8 @@
     },
     "node_modules/brcast": {
       "version": "2.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -7356,6 +7357,7 @@
     "node_modules/deepmerge": {
       "version": "1.5.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7586,6 +7588,7 @@
     "node_modules/direction": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "direction": "cli.js"
       },
@@ -19703,6 +19706,7 @@
     "node_modules/react-with-direction": {
       "version": "1.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "airbnb-prop-types": "^2.10.0",
         "brcast": "^2.0.2",
@@ -26179,9 +26183,7 @@
     "ajv-formats": {
       "version": "2.1.1",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      }
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -27035,7 +27037,8 @@
       }
     },
     "brcast": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "peer": true
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -28096,7 +28099,8 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "1.5.2"
+      "version": "1.5.2",
+      "peer": true
     },
     "defaults": {
       "version": "1.0.3",
@@ -28252,7 +28256,8 @@
       }
     },
     "direction": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "peer": true
     },
     "discontinuous-range": {
       "version": "1.0.0",
@@ -36589,7 +36594,6 @@
         "react-moment-proptypes": "^1.6.0",
         "react-outside-click-handler": "^1.2.4",
         "react-portal": "^4.2.0",
-        "react-with-direction": "^1.3.1",
         "react-with-styles": "^4.1.0",
         "react-with-styles-interface-css": "^6.0.0"
       }
@@ -36628,9 +36632,7 @@
     },
     "react-moment-proptypes": {
       "version": "1.8.1",
-      "requires": {
-        "moment": ">=1.6.0"
-      }
+      "requires": {}
     },
     "react-outside-click-handler": {
       "version": "1.3.0",
@@ -36650,6 +36652,7 @@
     },
     "react-with-direction": {
       "version": "1.3.1",
+      "peer": true,
       "requires": {
         "airbnb-prop-types": "^2.10.0",
         "brcast": "^2.0.2",
@@ -36667,8 +36670,7 @@
         "airbnb-prop-types": "^2.14.0",
         "hoist-non-react-statics": "^3.2.1",
         "object.assign": "^4.1.0",
-        "prop-types": "^15.7.2",
-        "react-with-direction": "^1.3.1"
+        "prop-types": "^15.7.2"
       }
     },
     "react-with-styles-interface-css": {

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -20,6 +20,7 @@ export {
   useMemo,
   useCallback,
   useImperativeHandle,
+  useReducer,
 } from 'preact/hooks';
 
 /**


### PR DESCRIPTION
Initial attempt at porting over pieces of the pan-zoom component to Bento.

Core of the component is based around a semi elaborate `useReducer` call to manage the multitude of variables that need to be managed. Some of these may be able to come out, but they were initially ported over just in case. Based on these state updates the component "watches" the relevant values (posX, posY and scale) via a useEffect at the top level. This is working fine for current implementation, but it would likely be pretty messy to handle animations with this current methodology. This was very much a "port the amp component as is" instead of trying to simply make a react component that recreates the behavior. It might be smart to explore this second option as you'll soon see where I started running into some denseness.

Bulk of the logic is in [reducer](extensions/amp-pan-zoom/1.0/reducer.ts) file. The reducer itself is a bit of a hybrid split between inline state updates and calling methods to derive state updates before returning. This is obviously a bit error prone as most switch cases require spreading existing state which could easily be missed and mess things up. I tried doing a bit more ~logical grouping of the updates, within the [actions](extensions/amp-pan-zoom/1.0/actions.ts) file, but things are still a bit fragile. Given more time I'd definitely explore simply using a hook sort of similar to the [sidebar](extensions/amp-sidebar/1.0/sidebar-animations-hook.js) to just pull everything out of the component itself and make some more meaningful abstractions.

What's been implemented (but may need some changes for supporting the parts that haven't been implemented 😬 )
- "raw" zoom in/out functionality by way of a zoom button. This matches existing behavior, but should be optional 
  - the actions associated with the "zoom in" could likely be slightly generalized to support double tapping/clicking to zoom in.
- once zoomed in, user can "click and hold" to pan the view of the content around

Not Implemented:
- touch support (tapping, pinch to zoom) hasn't been implemented, or hardly explored yet. Most of the touch functionality should map to clicks, but the existing version got into some animations and acceleration calculations to make it feel more native. No idea if this has to come across, but it will definitely introduce more complexity for animation state management/cancelation/finish support.
- original version doesn't support trackpad gestures or scroll-wheel for zoom functionality, so shouldn't be required for initial Bento version
- accessibility beyond what the base element provides

Some logic that was ported, but I either hadn't had a chance to use, or no longer needed, but may still be semi relevant I moved into an [not_yet_used.ts](extensions/amp-pan-zoom/1.0/not_yet_used.ts) to de clutter things at least a little bit.